### PR TITLE
Updated specs per newer version of rspec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ tmp/*
 coverage/
 data/
 .rbx
+
+*.swp
+*~

--- a/spec/clock_plugin_spec.rb
+++ b/spec/clock_plugin_spec.rb
@@ -67,7 +67,7 @@ describe "The Clock plugin" do
       it { should respond_to :execute }
       describe "#execute(m, type)" do
         it "takes at least two arguments for execute" do
-          expect { subject.execute(cinch_mock, "subcommand") }.should_not raise_error
+          expect { subject.execute(cinch_mock, "subcommand") }.to_not raise_error
         end
 
         it "should clock you in when you pass it the type 'in'" do

--- a/spec/clock_spec.rb
+++ b/spec/clock_spec.rb
@@ -20,7 +20,7 @@ describe Clock do
   it { should respond_to :clock_in }
   describe "#clock_in" do
     it "takes a username as an argument" do
-      expect { subject.clock_in("test_username") }.should_not raise_error
+      expect { subject.clock_in("test_username") }.to_not raise_error
     end
 
     it "should create a tick on the user's timesheet" do
@@ -35,7 +35,7 @@ describe Clock do
   it { should respond_to :clock_out }
   describe "#clock_out" do
     it "takes a username as an argument" do
-      expect { subject.clock_out("test_username") }.should_not raise_error
+      expect { subject.clock_out("test_username") }.to_not raise_error
     end
 
     it "should create a tick on the user's timesheet" do
@@ -49,7 +49,7 @@ describe Clock do
 
   describe "#for(user)" do
     it "takes a single user as an argument" do
-      expect { subject.for("foo") }.should_not raise_error
+      expect { subject.for("foo") }.to_not raise_error
     end
 
     it "should return an empty list if no ticks are present" do

--- a/spec/tick_spec.rb
+++ b/spec/tick_spec.rb
@@ -44,13 +44,13 @@ describe Tick do #class methods
 
   describe ".in" do
     it "takes no arguments" do
-      expect { subject.in }.should_not raise_error
+      expect { subject.in }.to_not raise_error
     end
   end
 
   describe ".out" do
     it "takes no arguments" do
-      expect { subject.out }.should_not raise_error
+      expect { subject.out }.to_not raise_error
     end
   end
 end

--- a/spec/timesheet_spec.rb
+++ b/spec/timesheet_spec.rb
@@ -9,13 +9,13 @@ describe Timesheet do #class methods
   it { should respond_to :entry }
   describe "#entry" do
     it "should take a username and a tick-type as an argument to .entry" do
-      expect { subject.entry('test_user', :in, reader) }.should_not raise_error
-      expect { subject.entry('test_user', :out, reader) }.should_not raise_error
+      expect { subject.entry('test_user', :in, reader) }.to_not raise_error
+      expect { subject.entry('test_user', :out, reader) }.to_not raise_error
     end
 
     it "optionally expects a dependency which responds to #open and #read" do
-      expect { subject.entry('test', :in, reader) }.should_not raise_error
-      expect { subject.entry('test', :in, invalid_reader) }.should raise_error
+      expect { subject.entry('test', :in, reader) }.to_not raise_error
+      expect { subject.entry('test', :in, invalid_reader) }.to raise_error
     end
 
     it "should throw an error if you try to make the same entry type twice in a row" do
@@ -35,7 +35,7 @@ type: :in
         reader.stub(:read).and_return(fake_data_after_clockin)
 
         subject.entry('test', :in, reader)
-      end.should raise_error InvalidTimesheetSequence
+      end.to raise_error InvalidTimesheetSequence
     end
   end
 


### PR DESCRIPTION
I'm not sure what version of rspec you are using and whether you would like to update or not. It would probably be a good idea to peg the version in the Gemfile. If you want to use an older version I'd be happy to edit the Gemfile instead and update my local install.
- ignore vim swap and backup files
  -changed "should" and "should_not" calls on RSpec::Expectation's to "to"
  and "to_not" since current version of rspec (2.11.0) doesn't support
  should syntax
