### PR TITLE
Fix spec_helper filepaths

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
 require 'rspec'
 
-require './lib/percival' 
+require '../lib/percival' 
 
-require './spec/support/irc_faker'
+require './support/irc_faker'


### PR DESCRIPTION
Running any RSpec test throws an error because the filepaths are incorrect.
